### PR TITLE
added links to pauseai montreal website

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,12 @@
             </div>
 
             <ul style="margin-left: 1.5rem; margin-bottom: 2rem;">
+                <li class="lang-en" style="margin-bottom: 1rem;">
+                    Join <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
+                </li>
+                <li class="lang-fr" style="margin-bottom: 1rem;">
+                    Rejoignez <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
+                </li>
                 <li class="lang-en" style="margin-bottom: 1rem;">Join the <a
                         href="https://www.meetup.com/montreal-ai-governance-ethics-safety/" target="_blank"
                         rel="noopener noreferrer">Montréal AI Governance, Ethics & Safety Meetups</a></li>
@@ -848,7 +854,7 @@
                             l'IA en convaincant les gouvernements de mettre en pause le développement d'IA surhumaines.
                             Nous informons le public, échangeons avec les politiciens, et organisons des événements.</p>
                         <div class="links">
-                            <a href="mailto:nicolas.m.lacombe@gmail.com" aria-label="Email PauseAI Montréal">Email</a>
+                            <a href="https://pauseai.ca/montreal.html" aria-label="Website PauseAI Montréal">Website</a>
                         </div>
                     </div>
 

--- a/index.html
+++ b/index.html
@@ -357,12 +357,6 @@
             </div>
 
             <ul style="margin-left: 1.5rem; margin-bottom: 2rem;">
-                <li class="lang-en" style="margin-bottom: 1rem;">
-                    Join <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
-                </li>
-                <li class="lang-fr" style="margin-bottom: 1rem;">
-                    Rejoignez <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
-                </li>
                 <li class="lang-en" style="margin-bottom: 1rem;">Join the <a
                         href="https://www.meetup.com/montreal-ai-governance-ethics-safety/" target="_blank"
                         rel="noopener noreferrer">Montréal AI Governance, Ethics & Safety Meetups</a></li>
@@ -370,6 +364,12 @@
                         href="https://www.meetup.com/montreal-ai-governance-ethics-safety/" target="_blank"
                         rel="noopener noreferrer">Meetup Montréal AI Governance, Ethics & Safety</a>
                     (grande communauté)</li>
+                <li class="lang-en" style="margin-bottom: 1rem;">
+                    Join <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
+                </li>
+                <li class="lang-fr" style="margin-bottom: 1rem;">
+                    Rejoignez <a href="https://pauseai.ca/montreal.html">PauseAI Montreal</a>
+                </li>
                 <li class="lang-en" style="margin-bottom: 1rem;">Contact <a href="mailto:team@horizonomega.org"
                         aria-label="Email Horizon Omega">Horizon Omega</a> for orientation or discussion about AI
                     in Montréal</li>


### PR DESCRIPTION
added link to pauseai mtl in the _Quick ways to get involved_ section, and 
updated _Communities_ section to link to pauseai mtl website instead of personal email